### PR TITLE
Update pre-commit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
+    rev: v1.1.13
     hooks:
       - id: remove-tabs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -29,6 +29,6 @@ repos:
       - id: pydocstyle
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,7 +6,7 @@ presubmits:
     context: aicoe-ci/prow/pre-commit
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.10
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.14.3
           command:
             - "pre-commit"
             - "run"


### PR DESCRIPTION
## Related Issues and Dependencies

At the moment, #42 is failing pre-commit checks. This version update would fix the current failure

## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Update to current pre-commit hook versions and image.

## Description

The current `black` version is failing with:

```
 black....................................................................Failed
- hook id: black
- exit code: 1
Traceback (most recent call last):
  File "/opt/app-root/src/.cache/pre-commit/repoevn2zel4/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/opt/app-root/src/.cache/pre-commit/repoevn2zel4/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 6606, in patched_main
    patch_click()
  File "/opt/app-root/src/.cache/pre-commit/repoevn2zel4/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 6595, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/opt/app-root/src/.cache/pre-commit/repoevn2zel4/py_env-python3/lib/python3.8/site-packages/click/__init__.py) 
```